### PR TITLE
Add methods to get untempered API responses

### DIFF
--- a/angular-cclib/resources/app.js
+++ b/angular-cclib/resources/app.js
@@ -34,6 +34,7 @@ angular.module('ngCclib').factory('App', ['$q', '$resource', 'Deployment', 'reso
         id: '@name'
     }, {
         get: {method: 'GET', interceptor: Interceptor, cache: resourceCache},
+        getorig: {method: 'GET', cache: resourceCache}, // untempered API response
         query: {method: 'GET', isArray: true, cache: resourceCache}
     });
 

--- a/angular-cclib/resources/deployment.js
+++ b/angular-cclib/resources/deployment.js
@@ -66,6 +66,7 @@ angular.module('ngCclib').factory('Deployment', ['$q', '$resource', 'Addon', 'Wo
         deploy: {method: 'PUT', interceptor: Interceptor},
         save: {method: 'POST', interceptor: Interceptor},
         get: {method: 'GET', interceptor: Interceptor, cache: resourceCache},
+        getorig: {method: 'GET', cache: resourceCache}, // untempered API response
         refresh: {method: 'GET', interceptor: RefreshInterceptor, cache: resourceCache}, // First clears cache in RefreshInterceptor and then caches new response from API
         query: {method: 'GET', isArray: true, interceptor: QueryInterceptor, cache: resourceCache}
     });


### PR DESCRIPTION
While most of the time it's beneficial to get resources recusively, e.g. deployments including add-ons and workers. Sometimes just the deployment is all we need. This change keeps the recursive way the default, but adds an additional method to the app and deployment resources.
